### PR TITLE
Add a function to calculate subplot grid size for attention layers

### DIFF
--- a/qwen2_5_implementation.ipynb
+++ b/qwen2_5_implementation.ipynb
@@ -15,6 +15,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import math \n",
+    "\n",
+    "def calculate_plt_size(attention_layer_num):    \n",
+    "    num_layers = attention_layer_num\n",
+    "    cols = math.ceil(math.sqrt(num_layers))  \n",
+    "    rows = math.ceil(num_layers / cols)     \n",
+    "    return rows, cols"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor\n",
     "import torch\n",
     "import matplotlib.pyplot as plt\n",
@@ -100,20 +115,23 @@
     "\n",
     "    output = model(**inputs, output_attentions=True)\n",
     "    general_output = model(**general_inputs, output_attentions=True)\n",
-    "\n",
-    "    fig, axes = plt.subplots(6, 6, figsize=(10.8, 16))\n",
+    "    rows, cols = calculate_plt_size(len(output.attentions))\n",
+    "    fig, axes = plt.subplots(rows, cols, figsize=(10.8, 16))\n",
     "    for i, ax in enumerate(axes.flatten()):\n",
-    "        att = output.attentions[i][0, :, -1, pos:pos_end].mean(dim=0)\n",
-    "        att = att.to(torch.float32).detach().cpu().numpy()\n",
+    "        if i < len(output.attentions): \n",
+    "            att = output.attentions[i][0, :, -1, pos:pos_end].mean(dim=0)\n",
+    "            att = att.to(torch.float32).detach().cpu().numpy()\n",
     "\n",
-    "        general_att = general_output.attentions[i][0, :, -1, pos:pos_end].mean(dim=0)\n",
-    "        general_att = general_att.to(torch.float32).detach().cpu().numpy()\n",
+    "            general_att = general_output.attentions[i][0, :, -1, pos:pos_end].mean(dim=0)\n",
+    "            general_att = general_att.to(torch.float32).detach().cpu().numpy()\n",
     "\n",
-    "        att = att / general_att\n",
+    "            att = att / general_att\n",
     "\n",
-    "        ax.imshow(att.reshape(output_shape), cmap='viridis', interpolation='nearest')\n",
-    "        ax.set_title(f'Layer {i+1}')\n",
-    "        ax.axis('off')\n",
+    "            ax.imshow(att.reshape(output_shape), cmap=\"viridis\", interpolation=\"nearest\")\n",
+    "            ax.set_title(f\"Layer {i+1}\")\n",
+    "            ax.axis(\"off\")\n",
+    "        else:\n",
+    "            ax.axis(\"off\")\n",
     "\n",
     "    plt.tight_layout()    \n",
     "    plt.show()    "
@@ -122,7 +140,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "panda-tmp",
+   "display_name": "qwen",
    "language": "python",
    "name": "python3"
   },
@@ -136,7 +154,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Since Qwen2.5 VL is a model family where different parameter configurations have varying hidden layer architectures, users may encounter errors when switching between models with different parameters.
So I add a function to calculate subplot grid size for attention layers,  and solve the problem.